### PR TITLE
Adding --ssl-insecure

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -94,15 +94,16 @@ type MigrationContext struct {
 	AliyunRDS                bool
 	GoogleCloudPlatform      bool
 
-	config            ContextConfig
-	configMutex       *sync.Mutex
-	ConfigFile        string
-	CliUser           string
-	CliPassword       string
-	UseTLS            bool
-	TLSCACertificate  string
-	CliMasterUser     string
-	CliMasterPassword string
+	config                ContextConfig
+	configMutex           *sync.Mutex
+	ConfigFile            string
+	CliUser               string
+	CliPassword           string
+	UseTLS                bool
+	TLSInsecureSkipVerify bool
+	TLSCACertificate      string
+	CliMasterUser         string
+	CliMasterPassword     string
 
 	HeartbeatIntervalMilliseconds       int64
 	defaultNumRetries                   int64

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -57,6 +57,7 @@ func main() {
 
 	flag.BoolVar(&migrationContext.UseTLS, "ssl", false, "Enable SSL encrypted connections to MySQL hosts")
 	flag.StringVar(&migrationContext.TLSCACertificate, "ssl-ca", "", "CA certificate in PEM format for TLS connections to MySQL hosts. Requires --ssl")
+	flag.StringVar(&migrationContext.TLSInsecureSkipVerify, "ssl-insecure", false, "Do not verify that the TLS connection is secure. Requires --ssl")
 
 	flag.StringVar(&migrationContext.DatabaseName, "database", "", "database name (mandatory)")
 	flag.StringVar(&migrationContext.OriginalTableName, "table", "", "table name (mandatory)")
@@ -200,6 +201,9 @@ func main() {
 	}
 	if migrationContext.TLSCACertificate != "" && !migrationContext.UseTLS {
 		log.Fatalf("--ssl-ca requires --ssl")
+	}
+	if migrationContext.TLSInsecureSkipVerify && !migrationContext.UseTLS {
+		log.Fatalf("--ssl-insecure requires --ssl")
 	}
 	if *replicationLagQuery != "" {
 		log.Warningf("--replication-lag-query is deprecated")


### PR DESCRIPTION
Adding `--ssl-insecure` option. With this PR, the behavior is

* `--ssl` by itself uses the system's CA pool
* `--ssl --ssl-ca=/path/to/ca.pem` uses a specific CA
* `--ssl --ssl-insecure` does not check that the connection is secure